### PR TITLE
Lattice type name cleanup

### DIFF
--- a/src/oqd_compiler_infrastructure/__init__.py
+++ b/src/oqd_compiler_infrastructure/__init__.py
@@ -20,7 +20,7 @@ from .dataflow import (
     GraphProtocol,
 )
 from .interface import TypeReflectBaseModel, VisitableBaseModel
-from .lattice import Lattice, LatticeBase, TBottom, TTop
+from .lattice import Lattice, LatticeBase, Bottom, Top
 from .rewriter import Chain, FixedPoint, RewriterBase
 from .rule import ConversionRule, PrettyPrint, RewriteRule, RuleBase
 from .walk import In, Level, Post, Pre, WalkBase
@@ -35,9 +35,9 @@ __all__ = [
     "GraphProtocol",
     "Lattice",
     "LatticeBase",
-    "TBottom",
+    "Bottom",
     "TList",
-    "TTop",
+    "Top",
     "type_name",
     "RewriteRule",
     "ConversionRule",

--- a/src/oqd_compiler_infrastructure/__init__.py
+++ b/src/oqd_compiler_infrastructure/__init__.py
@@ -20,7 +20,7 @@ from .dataflow import (
     GraphProtocol,
 )
 from .interface import TypeReflectBaseModel, VisitableBaseModel
-from .lattice import Lattice, LatticeBase, Bottom, Top
+from .lattice import Lattice, LatticeBase, LatticeBottom, LatticeTop
 from .rewriter import Chain, FixedPoint, RewriterBase
 from .rule import ConversionRule, PrettyPrint, RewriteRule, RuleBase
 from .walk import In, Level, Post, Pre, WalkBase
@@ -35,9 +35,8 @@ __all__ = [
     "GraphProtocol",
     "Lattice",
     "LatticeBase",
-    "Bottom",
-    "TList",
-    "Top",
+    "LatticeBottom",
+    "LatticeTop",
     "type_name",
     "RewriteRule",
     "ConversionRule",

--- a/src/oqd_compiler_infrastructure/lattice.py
+++ b/src/oqd_compiler_infrastructure/lattice.py
@@ -19,15 +19,15 @@ from typing import Generic, TypeVar
 ########################################################################################
 
 
-class Top:
+class LatticeTop:
     """
     Base class representing the top element of the lattice.
-    In `LatticeBase`, nodes are classes that inherit from `Top`.
+    In `LatticeBase`, nodes are classes that inherit from `LatticeTop`.
     """
     pass
 
 
-class Bottom(Top):
+class LatticeBottom(LatticeTop):
     """
     Base class representing the bottom element of the lattice.
     """
@@ -69,14 +69,14 @@ class LatticeBase(Lattice[LatticeType]):
         The map is a dictionary that maps each node of the lattice to its immediate parent(s).
         """
         self.map_node_to_parents = {
-            Bottom: (),
-            Top: (),
+            LatticeBottom: (),
+            LatticeTop: (),
         }
     
     
     def is_class_node(self, t: object) -> bool:
         """Returns True if `t` is a valid lattice node."""
-        return isinstance(t, type) and issubclass(t, Top)
+        return isinstance(t, type) and issubclass(t, LatticeTop)
     
     
     def add_node(self, t, parent):
@@ -101,7 +101,7 @@ class LatticeBase(Lattice[LatticeType]):
     
     def leq(self, t1: LatticeType, t2: LatticeType) -> bool:
         """Returns True if `t1 <= t2` in the lattice."""
-        if t1 is Bottom:
+        if t1 is LatticeBottom:
             return True
         if not self.is_class_node(t1) or not self.is_class_node(t2):
             return False
@@ -117,10 +117,10 @@ class LatticeBase(Lattice[LatticeType]):
         if self.leq(t2, t1):
             return t1
         if not self.is_class_node(t1) or not self.is_class_node(t2):
-            return Top
+            return LatticeTop
         common_ancestors = self.atomic_ancestors(t1).intersection(self.atomic_ancestors(t2))
         if not common_ancestors:
-            return Top
+            return LatticeTop
         
         minimal_ancestors = set()
         for candidate in common_ancestors:
@@ -131,7 +131,7 @@ class LatticeBase(Lattice[LatticeType]):
             if not smaller:
                 minimal_ancestors.add(candidate)
         if len(minimal_ancestors) != 1:
-            return Top
+            return LatticeTop
         return next(iter(minimal_ancestors))
     
     
@@ -141,5 +141,5 @@ class LatticeBase(Lattice[LatticeType]):
             return t1
         if self.leq(t2, t1):
             return t2
-        return Bottom
+        return LatticeBottom
     

--- a/src/oqd_compiler_infrastructure/lattice.py
+++ b/src/oqd_compiler_infrastructure/lattice.py
@@ -19,15 +19,15 @@ from typing import Generic, TypeVar
 ########################################################################################
 
 
-class TTop:
+class Top:
     """
     Base class representing the top element of the lattice.
-    In `LatticeBase`, nodes are classes that inherit from `TTop`.
+    In `LatticeBase`, nodes are classes that inherit from `Top`.
     """
     pass
 
 
-class TBottom(TTop):
+class Bottom(Top):
     """
     Base class representing the bottom element of the lattice.
     """
@@ -69,14 +69,14 @@ class LatticeBase(Lattice[LatticeType]):
         The map is a dictionary that maps each node of the lattice to its immediate parent(s).
         """
         self.map_node_to_parents = {
-            TBottom: (),
-            TTop: (),
+            Bottom: (),
+            Top: (),
         }
     
     
     def is_class_node(self, t: object) -> bool:
         """Returns True if `t` is a valid lattice node."""
-        return isinstance(t, type) and issubclass(t, TTop)
+        return isinstance(t, type) and issubclass(t, Top)
     
     
     def add_node(self, t, parent):
@@ -101,7 +101,7 @@ class LatticeBase(Lattice[LatticeType]):
     
     def leq(self, t1: LatticeType, t2: LatticeType) -> bool:
         """Returns True if `t1 <= t2` in the lattice."""
-        if t1 is TBottom:
+        if t1 is Bottom:
             return True
         if not self.is_class_node(t1) or not self.is_class_node(t2):
             return False
@@ -117,10 +117,10 @@ class LatticeBase(Lattice[LatticeType]):
         if self.leq(t2, t1):
             return t1
         if not self.is_class_node(t1) or not self.is_class_node(t2):
-            return TTop
+            return Top
         common_ancestors = self.atomic_ancestors(t1).intersection(self.atomic_ancestors(t2))
         if not common_ancestors:
-            return TTop
+            return Top
         
         minimal_ancestors = set()
         for candidate in common_ancestors:
@@ -131,7 +131,7 @@ class LatticeBase(Lattice[LatticeType]):
             if not smaller:
                 minimal_ancestors.add(candidate)
         if len(minimal_ancestors) != 1:
-            return TTop
+            return Top
         return next(iter(minimal_ancestors))
     
     
@@ -141,5 +141,5 @@ class LatticeBase(Lattice[LatticeType]):
             return t1
         if self.leq(t2, t1):
             return t2
-        return TBottom
+        return Bottom
     

--- a/tests/test_lattice.py
+++ b/tests/test_lattice.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import pytest
-from oqd_compiler_infrastructure import LatticeBase, TBottom, TTop
+from oqd_compiler_infrastructure import LatticeBase, Bottom, Top
 
-class A(TTop):
+class A(Top):
     pass
 
 class B(A):
@@ -27,20 +27,20 @@ class C(A):
 class TestLatticeBase:
     @pytest.fixture
     def lattice(self):
-        l = LatticeBase()
-        l.add_node(A, TTop)
-        l.add_node(B, A)
-        l.add_node(C, A)
-        return l
+        lattice_obj = LatticeBase()
+        lattice_obj.add_node(A, Top)
+        lattice_obj.add_node(B, A)
+        lattice_obj.add_node(C, A)
+        return lattice_obj
     
     def test_leq(self, lattice):
-        assert lattice.leq(A, TTop)
+        assert lattice.leq(A, Top)
         assert lattice.leq(B, A)
-        assert lattice.leq(B, TTop)
-        assert lattice.leq(TBottom, B)
+        assert lattice.leq(B, Top)
+        assert lattice.leq(Bottom, B)
 
     def test_join(self, lattice):
         assert lattice.join(B, C) == A
 
     def test_meet(self, lattice):
-        assert lattice.meet(B, C) == TBottom
+        assert lattice.meet(B, C) == Bottom

--- a/tests/test_lattice.py
+++ b/tests/test_lattice.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import pytest
-from oqd_compiler_infrastructure import LatticeBase, Bottom, Top
+from oqd_compiler_infrastructure import LatticeBase, LatticeBottom, LatticeTop
 
-class A(Top):
+class A(LatticeTop):
     pass
 
 class B(A):
@@ -28,19 +28,19 @@ class TestLatticeBase:
     @pytest.fixture
     def lattice(self):
         lattice_obj = LatticeBase()
-        lattice_obj.add_node(A, Top)
+        lattice_obj.add_node(A, LatticeTop)
         lattice_obj.add_node(B, A)
         lattice_obj.add_node(C, A)
         return lattice_obj
     
     def test_leq(self, lattice):
-        assert lattice.leq(A, Top)
+        assert lattice.leq(A, LatticeTop)
         assert lattice.leq(B, A)
-        assert lattice.leq(B, Top)
-        assert lattice.leq(Bottom, B)
+        assert lattice.leq(B, LatticeTop)
+        assert lattice.leq(LatticeBottom, B)
 
     def test_join(self, lattice):
         assert lattice.join(B, C) == A
 
     def test_meet(self, lattice):
-        assert lattice.meet(B, C) == Bottom
+        assert lattice.meet(B, C) == LatticeBottom


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Clean


* **What is the current behavior?** (You can also link to an open issue here)
Generic lattice types as TTop and TBottom.


* **What is the new behavior (if this is a feature change)?**
Generic lattice types will be LatticeTop and LatticeBottom.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, users who import TTop and TBottom should switch to LatticeTop and LatticeBottom.


* **Other information**:
N/A